### PR TITLE
test: trigger reviewdog workflow

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -48,7 +48,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -11,6 +11,9 @@
           "bun": {
             "version_added": "1.0.0"
           },
+          "firefox": {
+            "version_added": "57"
+          },
           "chrome": {
             "version_added": "66"
           },
@@ -20,9 +23,6 @@
           },
           "edge": {
             "version_added": "16"
-          },
-          "firefox": {
-            "version_added": "57"
           },
           "firefox_android": "mirror",
           "nodejs": {


### PR DESCRIPTION
Test PR to verify the lint:fix + reviewdog workflow.

Intentionally places `firefox` before `chrome` in `api/AbortController.json`, breaking the expected browser ordering. The `lint` CI job should fail, run `lint:fix` to produce a diff, upload it as an artifact, and then the `PR Reviewdog` workflow should post an inline suggested change via reviewdog.